### PR TITLE
Add REST API endpoints

### DIFF
--- a/src/app/api/papers/route.ts
+++ b/src/app/api/papers/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { getMatchingPapers, PaperSearchParams } from '@/lib/actions/papers';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  const search = searchParams.get('search') || undefined;
+  const page = searchParams.get('page') || undefined;
+  const venueAbbrevs = searchParams.getAll('venue') || [];
+  const yearMin = searchParams.get('year_min') || undefined;
+  const yearMax = searchParams.get('year_max') || undefined;
+  const hasCode = searchParams.get('has_code') === 'true';
+
+  // Log the search parameters, useful for debugging
+  // console.log("Search params:", { search, venueAbbrevs, page, yearMin, yearMax, hasCode });
+
+  const params = {
+    venue_abbrevs: venueAbbrevs,
+    search,
+    page,
+    year_min: yearMin,
+    year_max: yearMax,
+    has_code: hasCode
+  };
+
+  try {
+    const results = await getMatchingPapers(params);
+    return NextResponse.json({
+      success: true,
+      count: results.length,
+      results,
+    });
+  } catch (error) {
+    console.error('Search error details:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: `Search failed: ${error instanceof Error ? error.message : String(error)}`
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/venues/route.ts
+++ b/src/app/api/venues/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getVenues } from '@/lib/actions/venues';
+
+export async function GET() {
+  try {
+    const venues = await getVenues();
+    return NextResponse.json({
+      success: true,
+      count: venues.length,
+      venues
+    });
+  } catch (error) {
+    console.error('Error fetching venues:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch venues'
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/actions/papers.ts
+++ b/src/lib/actions/papers.ts
@@ -69,12 +69,12 @@ export async function getMatchingPapers(
     {
       body: {
         search,
-        page,
+        page: page || "1",
         per_page: PER_PAGE,
-        venue_abbrevs,
-        year_min,
-        year_max,
-        has_code,
+        venue_abbrevs: venue_abbrevs || [],
+        year_min: year_min || "1900",
+        year_max: year_max || new Date().getFullYear().toString(),
+        has_code: has_code || false,
       },
     },
   );


### PR DESCRIPTION
adds 2 GET requests:

`api/venues` - to get a list of all avaialble venues
`api/papers` - to query papers using semantic embeddings

Example usage:

`curl "http://localhost:3000/api/venues"`

or

` curl -X GET "http://localhost:3000/api/papers?venue_abbrevs=NeurIPS&search=transformer%20architectures&page=1&year_min=2020&year_max=2023&has_code=false"`

Note you don't need to pass all the params, sane defaults were added to supabase. Without them , if a param is missing in the curl request, an empty list was returned