### PR TITLE
Bugfix: Link logo to home page

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -3,6 +3,7 @@ import SignInButton from "@/components/buttons/sign-in";
 import { ColorSchemeToggle } from "@/components/color-scheme-toggle";
 import { Box, Container, Group, Stack, Text, ActionIcon } from "@mantine/core";
 import { IconPaperclip, IconBrandGithub } from "@tabler/icons-react";
+import Link from "next/link";
 
 export default function PublicLayout({
   children,
@@ -20,12 +21,14 @@ export default function PublicLayout({
           }}
         >
           <Group justify="space-between" align="center" w="100%">
-            <Group>
-              <IconPaperclip size={28} stroke={1.5} />
-              <Text size="xl" fw={700}>
-                Papers
-              </Text>
-            </Group>
+            <Link href="/" style={{ textDecoration: "none", color: "inherit" }}>
+              <Group>
+                <IconPaperclip size={28} stroke={1.5} />
+                <Text size="xl" fw={700}>
+                  Papers
+                </Text>
+              </Group>
+            </Link>
             <Group>
               <ActionIcon
                 variant="subtle"

--- a/src/layouts/sidebar-v2.tsx
+++ b/src/layouts/sidebar-v2.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tabler/icons-react";
 import { Center, Stack, Box, useMantineTheme } from "@mantine/core";
 import { usePathname } from "next/navigation";
+import Link from "next/link";
 import { logout } from "@/lib/actions/auth";
 import { useTransition } from "react";
 import { NavbarLink } from "./nav-link";
@@ -47,7 +48,9 @@ export function NavbarMinimal() {
       }}
     >
       <Center>
-        <IconPaperclip size={28} stroke={1.5} />
+        <Link href="/dashboard" style={{ color: "inherit", display: "inline-flex" }} aria-label="Home">
+          <IconPaperclip size={28} stroke={1.5} />
+        </Link>
       </Center>
 
       <Box style={{ flex: 1, marginTop: 50 }}>


### PR DESCRIPTION
Wraps the Papers logo in both the public header and the private sidebar in a Next.js Link so clicking it navigates home (/ for public, /dashboard for signed-in users) instead of being inert.