### PR TITLE
Docs: add API reference, llms.txt and OpenAPI spec

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,67 @@
+# Papers
+
+> Semantic search over machine-learning conference papers (NeurIPS, ICML, ICLR, PMLR and
+> others). Papers exposes a small read-only JSON API intended for agents and scripts.
+> No authentication or API key is required.
+
+Search is embedding-based: your query string is embedded with a `gte-small` model and
+matched against paper abstracts by pgvector cosine similarity (threshold 0.8). Prefer
+natural-language topical queries ("sparse attention for long context") over keyword
+strings ("sparse AND attention") — the latter will match poorly.
+
+Base URL: `https://papers.app`
+
+## Endpoints
+
+- [GET /api/papers](https://papers.app/api/papers): Search or browse papers. Query params:
+  `search` (natural-language query; omit to browse), `page` (1-based, 50 results per page),
+  `venue` (venue abbreviation, repeat the param for multiple), `year_min`, `year_max`,
+  `has_code` (pass the literal string `true`).
+  Returns `{ "success": true, "count": <int>, "results": [<paper>, ...] }`.
+- [GET /api/venues](https://papers.app/api/venues): List indexed venue abbreviations, for
+  use as `venue` filter values. Returns `{ "success": true, "count": <int>, "venues": [{ "abbrev": "NeurIPS" }, ...] }`.
+- [OpenAPI 3.1 specification](https://papers.app/openapi.json): Machine-readable schema for both endpoints.
+- [Human documentation](https://papers.app/docs): Same reference with worked examples.
+- [Coverage](https://papers.app/coverage): Which conferences and years are actually indexed.
+
+## Paper fields
+
+Each entry in `results` contains: `id`, `title`, `authors` (array of strings), `abstract`,
+`year`, `abbrev` (venue), `pdf_url`, `code_url`, `arxiv_id`, `arxiv_url`, `like_count`,
+`view_count`, `created_at`.
+
+Responses may also contain additional internal fields — notably `abstract_embedding`, a
+large raw vector — which are **not** part of the stable contract. Ignore any field not
+listed above; do not parse or depend on them.
+
+## Examples
+
+```
+curl "https://papers.app/api/papers?search=sparse+attention+for+long+context"
+curl "https://papers.app/api/papers?search=diffusion+models&venue=NeurIPS&year_min=2023&has_code=true"
+curl "https://papers.app/api/papers?venue=ICML&year_min=2024&page=2"
+curl "https://papers.app/api/venues"
+```
+
+## Behaviour worth knowing
+
+- `count` is the number of results **on the current page**, not the total number of
+  matches. There is no total-count field. Infer the last page from `count` < 50.
+- Without `search`, result ordering is unspecified. Do not rely on it being sorted by
+  date or relevance. Pass `search` when you need ranked results.
+- `has_code` only activates on the exact string `true`. Any other value is treated as false.
+- Non-numeric `year_min` / `year_max` currently return HTTP 500 rather than 400.
+- Errors return `{ "success": false, "error": "<message>" }`.
+- Responses are cached for 300 seconds (`s-maxage=300, stale-while-revalidate=60`).
+
+## Usage expectations
+
+Each distinct `search` string costs an embedding computation and a vector scan, so it is
+not free to serve. There is currently no enforced rate limit; please stay under roughly
+20 search requests per minute, reuse identical query strings rather than perturbing them,
+and request only the pages you need. Rate limiting will be introduced, at which point
+exceeding it will return HTTP 429 with a `Retry-After` header — handle that status now if
+you are writing a long-running client.
+
+Paper metadata is scraped from public conference proceedings. Abstracts remain the
+copyright of their original authors and publishers.

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1,0 +1,264 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Papers API",
+    "version": "1.0.0",
+    "summary": "Read-only semantic search over machine-learning conference papers.",
+    "description": "Search and browse papers from ML conference proceedings (NeurIPS, ICML, ICLR, PMLR and others).\n\nSearch is embedding-based: the `search` string is embedded with a `gte-small` model and matched against paper abstracts using pgvector cosine similarity (threshold 0.8). Prefer natural-language topical queries over boolean keyword strings.\n\nNo authentication is required. There is currently no enforced rate limit; clients should stay under roughly 20 search requests per minute and be prepared to handle HTTP 429 with a `Retry-After` header, which will be introduced later.",
+    "contact": {
+      "name": "Papers",
+      "url": "https://papers.app"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://papers.app",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "papers",
+      "description": "Paper search and browse"
+    },
+    {
+      "name": "venues",
+      "description": "Indexed conference venues"
+    }
+  ],
+  "paths": {
+    "/api/papers": {
+      "get": {
+        "operationId": "searchPapers",
+        "tags": ["papers"],
+        "summary": "Search or browse papers",
+        "description": "When `search` is provided, results are ranked by semantic similarity to the query. When `search` is omitted, the endpoint browses the paper table with filters applied and **result ordering is unspecified**.\n\nPage size is fixed at 50. The `count` field reports the number of results on the current page, not the total number of matches; infer the last page from a `count` below 50.",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": false,
+            "description": "Natural-language topical query, e.g. \"sparse attention for long context\". Omit to browse without ranking. Each distinct value costs an embedding computation, so reuse identical strings where possible.",
+            "schema": { "type": "string" },
+            "example": "sparse attention for long context"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "1-based page number. 50 results per page.",
+            "schema": { "type": "integer", "minimum": 1, "default": 1 },
+            "example": 1
+          },
+          {
+            "name": "venue",
+            "in": "query",
+            "required": false,
+            "description": "Venue abbreviation to filter by. Repeat the parameter to include several venues (`?venue=NeurIPS&venue=ICML`). Valid values come from `GET /api/venues`.",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "example": ["NeurIPS"]
+          },
+          {
+            "name": "year_min",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive lower bound on publication year. Non-numeric values currently produce a 500 response rather than a 400.",
+            "schema": { "type": "integer" },
+            "example": 2023
+          },
+          {
+            "name": "year_max",
+            "in": "query",
+            "required": false,
+            "description": "Inclusive upper bound on publication year. Non-numeric values currently produce a 500 response rather than a 400.",
+            "schema": { "type": "integer" },
+            "example": 2026
+          },
+          {
+            "name": "has_code",
+            "in": "query",
+            "required": false,
+            "description": "Restrict to papers with a known code URL. Only the exact string `true` enables the filter; any other value is treated as false.",
+            "schema": { "type": "string", "enum": ["true"] },
+            "example": "true"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching papers.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always `public, s-maxage=300, stale-while-revalidate=60`.",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PapersResponse" }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Not currently returned, but reserved — handle it in long-running clients.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "schema": { "type": "integer" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Search failed. Also returned for malformed numeric parameters.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/venues": {
+      "get": {
+        "operationId": "listVenues",
+        "tags": ["venues"],
+        "summary": "List indexed venue abbreviations",
+        "description": "Returns the venue abbreviations available as `venue` filter values on `GET /api/papers`. For which years are covered per venue, see https://papers.app/coverage.",
+        "responses": {
+          "200": {
+            "description": "Indexed venues.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always `public, s-maxage=300, stale-while-revalidate=60`.",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VenuesResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to fetch venues.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PapersResponse": {
+        "type": "object",
+        "required": ["success", "count", "results"],
+        "properties": {
+          "success": { "type": "boolean", "const": true },
+          "count": {
+            "type": "integer",
+            "description": "Number of results on this page — NOT the total number of matches."
+          },
+          "results": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Paper" }
+          }
+        }
+      },
+      "VenuesResponse": {
+        "type": "object",
+        "required": ["success", "count", "venues"],
+        "properties": {
+          "success": { "type": "boolean", "const": true },
+          "count": { "type": "integer" },
+          "venues": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Venue" }
+          }
+        }
+      },
+      "Venue": {
+        "type": "object",
+        "properties": {
+          "abbrev": {
+            "type": ["string", "null"],
+            "description": "Venue abbreviation, usable as a `venue` filter value.",
+            "examples": ["NeurIPS", "ICML", "ICLR"]
+          }
+        }
+      },
+      "Paper": {
+        "type": "object",
+        "description": "A paper record. Responses may include additional internal fields that are not part of the stable contract — notably `abstract_embedding` (a large raw vector), plus `venue_id`, `status` and `normalized_title`. Ignore any property not documented here; do not parse or depend on them.",
+        "additionalProperties": true,
+        "properties": {
+          "id": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": "Stable identifier for the paper."
+          },
+          "title": { "type": ["string", "null"] },
+          "authors": {
+            "type": ["array", "null"],
+            "items": { "type": "string" },
+            "description": "Author names, in publication order.",
+            "examples": [["Ada Lovelace", "Alan Turing"]]
+          },
+          "abstract": { "type": ["string", "null"] },
+          "year": {
+            "type": ["integer", "null"],
+            "description": "Publication year of the venue.",
+            "examples": [2025]
+          },
+          "abbrev": {
+            "type": ["string", "null"],
+            "description": "Abbreviation of the venue the paper appeared in.",
+            "examples": ["NeurIPS"]
+          },
+          "pdf_url": { "type": ["string", "null"], "format": "uri" },
+          "code_url": {
+            "type": ["string", "null"],
+            "format": "uri",
+            "description": "Repository URL, when one is known. Null unless discovered."
+          },
+          "arxiv_id": { "type": ["string", "null"], "examples": ["2401.01234"] },
+          "arxiv_url": { "type": ["string", "null"], "format": "uri" },
+          "like_count": {
+            "type": ["integer", "null"],
+            "description": "Likes from Papers users."
+          },
+          "view_count": {
+            "type": ["integer", "null"],
+            "description": "Views from Papers users."
+          },
+          "created_at": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "When the record was ingested, not when the paper was published."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["success", "error"],
+        "properties": {
+          "success": { "type": "boolean", "const": false },
+          "error": { "type": "string", "description": "Human-readable error message." }
+        }
+      }
+    }
+  }
+}

--- a/src/app/(public)/docs/page.tsx
+++ b/src/app/(public)/docs/page.tsx
@@ -1,0 +1,288 @@
+import { getVenues } from "@/lib/actions/venues";
+import {
+  Anchor,
+  Badge,
+  Card,
+  Code,
+  Container,
+  Divider,
+  Group,
+  List,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from "@mantine/core";
+
+export const revalidate = 300;
+
+export const metadata = {
+  title: "Papers — API",
+  description:
+    "Read-only JSON API for semantic search over ML conference papers.",
+};
+
+const PAPER_PARAMS: [string, string, string][] = [
+  [
+    "search",
+    "string",
+    "Natural-language topical query. Omit to browse without ranking. Each distinct value costs an embedding computation.",
+  ],
+  ["page", "integer", "1-based page number. 50 results per page. Defaults to 1."],
+  [
+    "venue",
+    "string (repeatable)",
+    "Venue abbreviation. Repeat the parameter for several venues: ?venue=NeurIPS&venue=ICML",
+  ],
+  ["year_min", "integer", "Inclusive lower bound on publication year."],
+  ["year_max", "integer", "Inclusive upper bound on publication year."],
+  [
+    "has_code",
+    'literal "true"',
+    "Restrict to papers with a known code URL. Only the exact string true enables it.",
+  ],
+];
+
+const PAPER_FIELDS: [string, string][] = [
+  ["id", "Stable identifier for the paper."],
+  ["title", "Paper title."],
+  ["authors", "Array of author names, in publication order."],
+  ["abstract", "Abstract text."],
+  ["year", "Publication year of the venue."],
+  ["abbrev", "Venue abbreviation, e.g. NeurIPS."],
+  ["pdf_url", "Link to the PDF."],
+  ["code_url", "Repository URL, when one is known. Null otherwise."],
+  ["arxiv_id", "arXiv identifier, when cross-referenced."],
+  ["arxiv_url", "arXiv abstract page."],
+  ["like_count", "Likes from Papers users."],
+  ["view_count", "Views from Papers users."],
+  ["created_at", "When the record was ingested — not when the paper was published."],
+];
+
+export default async function ApiDocsPage() {
+  const venues = await getVenues();
+  const abbrevs = venues
+    .map((v) => v.abbrev)
+    .filter((a): a is string => Boolean(a))
+    .sort((a, b) => a.localeCompare(b));
+
+  return (
+    <Container size="lg" py="xl" style={{ overflowY: "auto", height: "100%" }}>
+      <Stack gap="xl">
+        <Stack gap={4}>
+          <Title order={2}>API</Title>
+          <Text c="dimmed" size="sm">
+            A read-only JSON API for semantic search over ML conference papers. No
+            authentication or API key required.
+          </Text>
+        </Stack>
+
+        <Stack gap="xs">
+          <Text size="sm">
+            Machine-readable versions:{" "}
+            <Anchor href="/openapi.json" size="sm">
+              OpenAPI 3.1 spec
+            </Anchor>{" "}
+            &middot;{" "}
+            <Anchor href="/llms.txt" size="sm">
+              llms.txt
+            </Anchor>{" "}
+            &middot;{" "}
+            <Anchor href="/coverage" size="sm">
+              venue &amp; year coverage
+            </Anchor>
+          </Text>
+        </Stack>
+
+        <Card withBorder radius="md" padding="md">
+          <Stack gap="sm">
+            <Text fw={600} size="sm">
+              Quick start
+            </Text>
+            <Code block>
+              {`curl "https://papers.app/api/papers?search=sparse+attention+for+long+context"`}
+            </Code>
+            <Text size="xs" c="dimmed">
+              Search is embedding-based: your query is embedded with a gte-small model and
+              matched against abstracts by cosine similarity. Prefer natural-language
+              topics (&ldquo;sparse attention for long context&rdquo;) over boolean keyword
+              strings (&ldquo;sparse AND attention&rdquo;), which match poorly.
+            </Text>
+          </Stack>
+        </Card>
+
+        <Divider />
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            <Code>GET /api/papers</Code>
+          </Title>
+          <Text size="sm" c="dimmed">
+            Search or browse papers. With <Code>search</Code>, results are ranked by
+            semantic similarity. Without it, filters still apply but ordering is
+            unspecified.
+          </Text>
+
+          <Table striped withTableBorder withColumnBorders>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Parameter</Table.Th>
+                <Table.Th>Type</Table.Th>
+                <Table.Th>Description</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {PAPER_PARAMS.map(([name, type, desc]) => (
+                <Table.Tr key={name}>
+                  <Table.Td>
+                    <Code>{name}</Code>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs" c="dimmed">
+                      {type}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm">{desc}</Text>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+
+          <Code block>
+            {`{
+  "success": true,
+  "count": 50,
+  "results": [
+    {
+      "id": "…",
+      "title": "…",
+      "authors": ["…", "…"],
+      "abstract": "…",
+      "year": 2025,
+      "abbrev": "NeurIPS",
+      "pdf_url": "…",
+      "code_url": null
+    }
+  ]
+}`}
+          </Code>
+        </Stack>
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            <Code>GET /api/venues</Code>
+          </Title>
+          <Text size="sm" c="dimmed">
+            Lists the venue abbreviations accepted by the <Code>venue</Code> filter.
+            Currently indexed:
+          </Text>
+          <Group gap="xs">
+            {abbrevs.map((abbrev) => (
+              <Badge key={abbrev} variant="light" radius="sm">
+                {abbrev}
+              </Badge>
+            ))}
+          </Group>
+          <Code block>
+            {`{ "success": true, "count": ${abbrevs.length}, "venues": [{ "abbrev": "${
+              abbrevs[0] ?? "NeurIPS"
+            }" }] }`}
+          </Code>
+        </Stack>
+
+        <Divider />
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            Paper fields
+          </Title>
+          <Table striped withTableBorder withColumnBorders>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Field</Table.Th>
+                <Table.Th>Description</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {PAPER_FIELDS.map(([name, desc]) => (
+                <Table.Tr key={name}>
+                  <Table.Td>
+                    <Code>{name}</Code>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="sm">{desc}</Text>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+          <Text size="xs" c="dimmed">
+            Responses may include additional internal fields — notably{" "}
+            <Code>abstract_embedding</Code>, a large raw vector, plus{" "}
+            <Code>venue_id</Code>, <Code>status</Code> and <Code>normalized_title</Code>.
+            These are not part of the stable contract. Ignore any field not listed above.
+          </Text>
+        </Stack>
+
+        <Divider />
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            Behaviour worth knowing
+          </Title>
+          <List size="sm" spacing="xs">
+            <List.Item>
+              <Code>count</Code> is the number of results on the current page, not the
+              total number of matches. There is no total-count field — infer the last page
+              from a <Code>count</Code> below 50.
+            </List.Item>
+            <List.Item>
+              Without <Code>search</Code>, result ordering is unspecified. Do not rely on
+              it being sorted by date or relevance.
+            </List.Item>
+            <List.Item>
+              <Code>has_code</Code> only activates on the exact string <Code>true</Code>.
+            </List.Item>
+            <List.Item>
+              Non-numeric <Code>year_min</Code> / <Code>year_max</Code> currently return
+              HTTP 500 rather than 400.
+            </List.Item>
+            <List.Item>
+              Errors return <Code>{`{ "success": false, "error": "…" }`}</Code>.
+            </List.Item>
+            <List.Item>
+              Responses are cached for 300 seconds (
+              <Code>s-maxage=300, stale-while-revalidate=60</Code>).
+            </List.Item>
+          </List>
+        </Stack>
+
+        <Card withBorder radius="md" padding="md">
+          <Stack gap="xs">
+            <Text fw={600} size="sm">
+              Usage expectations
+            </Text>
+            <Text size="sm">
+              Each distinct <Code>search</Code> string costs an embedding computation and a
+              vector scan, so it is not free to serve. There is currently no enforced rate
+              limit — please stay under roughly 20 search requests per minute, reuse
+              identical query strings rather than perturbing them, and request only the
+              pages you need.
+            </Text>
+            <Text size="sm">
+              Rate limiting will be introduced, at which point exceeding it returns HTTP
+              429 with a <Code>Retry-After</Code> header. Handle that status now if you are
+              writing a long-running client.
+            </Text>
+            <Text size="xs" c="dimmed">
+              Paper metadata is scraped from public conference proceedings. Abstracts
+              remain the copyright of their original authors and publishers.
+            </Text>
+          </Stack>
+        </Card>
+      </Stack>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary

Documents the existing `/api/papers` and `/api/venues` endpoints so agents and scripts can use them. No runtime or behaviour changes — three new files only.

- `public/llms.txt` → `/llms.txt`
- `public/openapi.json` → `/openapi.json` (OpenAPI 3.1)
- `src/app/(public)/docs/page.tsx` → `/docs`, Mantine, renders the live venue list via `getVenues()`

Content was written against the actual response shapes rather than assumed, so it documents the real behaviour including the rough edges: `count` is the page size and not a total, ordering is unspecified without `search`, `has_code` only activates on the literal string `true`, and malformed year params return 500 rather than 400.

## Notes for review

**Internal fields are documented as unstable, not supported.** Both search paths use `select("*")` on `vw_final_papers` (`src/lib/actions/papers.ts:64`, `supabase/functions/search/index.ts:45`), so every response carries `abstract_embedding` — a 384-dim vector serialised as a string, 50 per page — plus `venue_id`, `status` and `normalized_title`. Nothing in `src/` reads any of them. Rather than enshrine them in the spec, they are documented as outside the stable contract, so trimming the select later is not a breaking change. Worth doing before agent traffic arrives, since agents pay per token for that payload.

**The 20 req/min courtesy limit is a placeholder.** It appears in all three files and is now a public commitment. Adjust before merge if that number is wrong — there is no enforced rate limit behind it yet.

**`/api/venues` only returns `abbrev`.** `vw_final_venues` has exactly one column, so there are no full conference names or years. Documented as such, with a pointer to `/coverage`.

## Follow-ups (not in this PR)

- `/docs` is not linked from any nav — reachable by direct URL only.
- `llms.txt` is conventionally referenced from `robots.txt`.

## Testing

- `tsc --noEmit` clean
- `next lint` clean
- `npm run build` succeeds, `/docs` registered as a dynamic route alongside `/coverage`

Not verified: runtime rendering of `/docs`. Local Supabase was not running, and the page is server-rendered on demand so the build did not exercise the `getVenues()` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)